### PR TITLE
Refactor: Move RunRecordQueryBO from enums to entity package

### DIFF
--- a/backend/src/main/java/ai/basic/x1/adapter/api/controller/ModelRunRecordController.java
+++ b/backend/src/main/java/ai/basic/x1/adapter/api/controller/ModelRunRecordController.java
@@ -5,7 +5,7 @@ import ai.basic.x1.adapter.dto.ModelRunRecordDTO;
 import ai.basic.x1.adapter.dto.request.RunRecordQueryDTO;
 import ai.basic.x1.adapter.port.rpc.dto.DatasetModelResultDTO;
 import ai.basic.x1.entity.ModelRunRecordBO;
-import ai.basic.x1.entity.enums.RunRecordQueryBO;
+import ai.basic.x1.entity.RunRecordQueryBO;
 import ai.basic.x1.usecase.ModelRunRecordUseCase;
 import ai.basic.x1.util.DefaultConverter;
 import ai.basic.x1.util.Page;

--- a/backend/src/main/java/ai/basic/x1/entity/RunRecordQueryBO.java
+++ b/backend/src/main/java/ai/basic/x1/entity/RunRecordQueryBO.java
@@ -1,6 +1,9 @@
-package ai.basic.x1.entity.enums;
+package ai.basic.x1.entity;
 
 import ai.basic.x1.adapter.api.annotation.valid.ValidStringEnum;
+import ai.basic.x1.entity.enums.RunRecordTypeEnum;
+import ai.basic.x1.entity.enums.RunStatusEnum;
+import ai.basic.x1.entity.enums.SortEnum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/backend/src/main/java/ai/basic/x1/usecase/ModelRunRecordUseCase.java
+++ b/backend/src/main/java/ai/basic/x1/usecase/ModelRunRecordUseCase.java
@@ -8,7 +8,7 @@ import ai.basic.x1.adapter.port.dao.mybatis.model.*;
 import ai.basic.x1.adapter.port.dao.redis.ModelSerialNoCountDAO;
 import ai.basic.x1.adapter.port.dao.redis.ModelSerialNoIncrDAO;
 import ai.basic.x1.entity.*;
-import ai.basic.x1.entity.enums.RunRecordQueryBO;
+import ai.basic.x1.entity.RunRecordQueryBO;
 import ai.basic.x1.entity.enums.RunStatusEnum;
 import ai.basic.x1.entity.enums.SortEnum;
 import ai.basic.x1.usecase.exception.UsecaseCode;


### PR DESCRIPTION
The `RunRecordQueryBO` was previously located in the enums package.

In alignment with the xtreme1's convention of placing BO in the entity package, I have moved the `RunRecordQueryBO` to the entity package.

Thank you:)