### PR TITLE
fix: Uploading files does not require loading into memory

### DIFF
--- a/.ops/dev/backend-deployment.yml
+++ b/.ops/dev/backend-deployment.yml
@@ -115,7 +115,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/upstream-vhost: basicai-dataset-tmp-minio-endpoint.alidev.beisai.com
-    nginx.ingress.kubernetes.io/proxy-body-size: 1000m
+    nginx.ingress.kubernetes.io/proxy-body-size: 1048576m
   name: minio
 spec:
   ingressClassName: nginx

--- a/frontend/main/src/views/datasets/datasetContent/components/upload/UploadProgress.vue
+++ b/frontend/main/src/views/datasets/datasetContent/components/upload/UploadProgress.vue
@@ -48,7 +48,6 @@
   import Icon, { SvgIcon } from '/@/components/Icon';
   import { FileItem } from './uploadTyping';
   import { UploadResultStatus } from '/@/components/Upload/src/typing';
-  import { getBufferWithFile } from '/@/components/Upload/src/helper';
   import {
     generatePresignedUrl,
     uploadDatasetApi,
@@ -302,7 +301,7 @@
           isUploading.value = false;
         }
       };
-      getBufferWithFile(fileItem.file).then(upload);
+      upload(fileItem);
     } else {
       isUploading.value = false;
     }


### PR DESCRIPTION
Uploading files does not require loading into memory. Solving the problem of browser memory explosion.
