### PR TITLE
fix: Add await before unlock to execute saveObject #280

### DIFF
--- a/frontend/pc-tool/src/components/Header/useHeader.ts
+++ b/frontend/pc-tool/src/components/Header/useHeader.ts
@@ -201,7 +201,7 @@ export default function useHeader() {
         bsState.submitting = true;
         try {
             if (isSeriesFrame) {
-                editor.saveObject(frames, true);
+                await editor.saveObject(frames, true);
                 await api.submitData(seriesFrameId ?? '');
                 // await updateDataStatus(frames);
                 unlockData();


### PR DESCRIPTION
#280 

Thank you all for your contributions and great features. They are always appreciated.