### PR TITLE
fix: update MinIO image (previous image deprecated)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
       start_period: 10s
       retries: 10
   minio:
-    image: bitnami/minio:2022.9.1
+    image: bitnamilegacy/minio:2025.7.23-debian-12-r5
+    platform: linux/arm64
     environment:
       MINIO_ROOT_USER: admin
       MINIO_ROOT_PASSWORD: 1tQB970y


### PR DESCRIPTION
## Problem
The current `docker-compose.yml` fails to build because the `bitnami/minio` image tags were removed from Docker Hub.

The MinIO image has been moved to the legacy repository:
https://hub.docker.com/r/bitnamilegacy/minio/tags

<img width="1573" height="1065" alt="image" src="https://github.com/user-attachments/assets/a32190d1-eef5-4227-9f35-e48f682e3267" />

## Solution
Updated the image in `docker-compose.yml` to a valid tag:

```yaml
image: bitnamilegacy/minio:2025.7.23-debian-12-r5
```

## Result
The setup now builds successfully, and Xtreme1 runs correctly in a local environment.

<img width="2455" height="1527" alt="image" src="https://github.com/user-attachments/assets/bec3b8ca-835b-46aa-abde-b8ad8dff62c4" />